### PR TITLE
refactor(event): make Event optional for KeyboardEvent

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -1,6 +1,6 @@
 const binding = require('../binding')
 
-module.exports = exports = class SDLEvent {
+class SDLEvent {
   constructor() {
     this._handle = binding.createEvent()
   }
@@ -15,7 +15,7 @@ module.exports = exports = class SDLEvent {
 }
 
 class SDLKeyboardEvent {
-  constructor(event) {
+  constructor(event = new SDLEvent()) {
     this._handle = binding.getEventKey(event._handle)
   }
 
@@ -24,4 +24,5 @@ class SDLKeyboardEvent {
   }
 }
 
-exports.Keyboard = SDLKeyboardEvent
+module.exports = SDLEvent
+module.exports.Keyboard = SDLKeyboardEvent

--- a/test/event.js
+++ b/test/event.js
@@ -12,11 +12,16 @@ test('Event class shouls expose a type getter initialized at zero', (t) => {
 })
 
 test('it should expose an Event.Keyboard class', (t) => {
-  const event = new sdl.Event.Keyboard(new sdl.Event())
+  const event = new sdl.Event.Keyboard()
   t.ok(event)
 })
 
 test('Event.Keyboard class shouls expose a scancode getter initialized at zero', (t) => {
-  const event = new sdl.Event.Keyboard(new sdl.Event())
+  const event = new sdl.Event.Keyboard()
   t.ok(event.scancode == 0)
+})
+
+test('Event.Keyboard should be initialized by passing an Event instance', (t) => {
+  const event = new sdl.Event.Keyboard(new sdl.Event())
+  t.ok(event)
 })


### PR DESCRIPTION
While writing doc, I wondered if it won't be simpler like that.